### PR TITLE
markdown-it: 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/Akirami/vue-markdown-V2/blob/master/README.md",
   "dependencies": {
     "highlight.js": "^9.12.0",
-    "markdown-it": "^8.4.2",
+    "markdown-it": "^10.0.0",
     "markdown-it-abbr": "^1.0.4",
     "markdown-it-container": "^2.0.0",
     "markdown-it-deflist": "^2.0.3",


### PR DESCRIPTION
Should fix https://app.snyk.io/vuln/SNYK-JS-MARKDOWNIT-459438.