### PR TITLE
(vulnerability-fix) highlightjs-10.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/Akirami/vue-markdown-V2/blob/master/README.md",
   "dependencies": {
-    "highlight.js": "^9.12.0",
+    "highlight.js": "^10.4.1",
     "markdown-it": "^10.0.0",
     "markdown-it-abbr": "^1.0.4",
     "markdown-it-container": "^2.0.0",


### PR DESCRIPTION
Modified package.json to bump highlight.js to 10.4.1 or higher to address https://app.snyk.io/vuln/SNYK-JS-HIGHLIGHTJS-1048676